### PR TITLE
Add mobile storage standards documentation

### DIFF
--- a/docs/mobile_standards.md
+++ b/docs/mobile_standards.md
@@ -61,7 +61,11 @@ In short: â€œCrash early, fix quickly, and handle gracefully where it matters.â€
 
 - Nullable types are handled appropriately with safe calls and nullability checks.
 - Use of Kotlin's built-in null safety features where necessary.
-- Change Java files to Kotlin when Java-Kotlin intercompatibility introduces unnecessary and significant boilerplate code. 
+- Change Java files to Kotlin when Java-Kotlin intercompatibility introduces unnecessary and significant boilerplate code.
+
+### Mobile Data Storage
+
+- [Sqlite vs Shared Preferences](https://github.com/dimagi/open-source/blob/master/docs/mobile_storage_standards.md)
 
 ### Async Processing
 

--- a/docs/mobile_storage_standards.md
+++ b/docs/mobile_storage_standards.md
@@ -10,7 +10,7 @@ Small, simple key-value data such as:
 * Last sync timestamp
 * Selected language
 * User settings
-* Small primitive user state
+* Small primitive user state like number of times a user has been shown a specific prompt or reminder
 
 **Best when:**
 
@@ -32,6 +32,7 @@ Structured, growing, or queryable data such as:
 * Offline business data
 * Queues / retries
 * Parent-child relationships
+* Data from Server APIs (generally structured persistent data)
 
 **Best when:**
 
@@ -56,13 +57,12 @@ Structured, growing, or queryable data such as:
 
 ## Avoid
 
-* Large JSON blobs in Shared Preferences
+* Using Shared Preferences for non-volatile data that might need backward compatibility or migrations across app versions
 * Using SQLite for isolated flags or intermediate properties
-* Complex structured data in Shared Preferences
 
 ---
 
 ## Team Principle
 
-**If data is state → Shared Preferences**
-**If data is records → SQLite**
+* If data is state → Shared Preferences
+* If data is records → SQLite**

--- a/docs/mobile_storage_standards.md
+++ b/docs/mobile_storage_standards.md
@@ -1,4 +1,4 @@
-# SQLite DB vs Shared Preferences
+# Mobile Storage: SQLite DB vs Shared Preferences
 
 ## Use Shared Preferences for:
 

--- a/docs/mobile_storage_standards.md
+++ b/docs/mobile_storage_standards.md
@@ -1,0 +1,68 @@
+# SQLite DB vs Shared Preferences
+
+## Use Shared Preferences for:
+
+Small, simple key-value data such as:
+
+* Theme / dark mode
+* Feature flags
+* First launch completed
+* Last sync timestamp
+* Selected language
+* User settings
+* Small primitive user state
+
+**Best when:**
+
+* Few values
+* Simple reads/writes
+* No querying needed
+* UI State
+
+---
+
+## Use SQLite DB for:
+
+Structured, growing, or queryable data such as:
+
+* Lists of records
+* Forms / submissions
+* Messages / history
+* Downloaded content
+* Offline business data
+* Queues / retries
+* Parent-child relationships
+
+**Best when:**
+
+* Many records
+* Need search / sort / filter
+* Need transactions
+* Data evolves over time
+
+---
+
+## Quick Decision Rule
+
+| If data is...           | Use                |
+| ----------------------- | ------------------ |
+| App settings / flags    | Shared Preferences |
+| Single values           | Shared Preferences |
+| Records / lists         | SQLite             |
+| Searchable / filterable | SQLite             |
+| Growing over time       | SQLite             |
+
+---
+
+## Avoid
+
+* Large JSON blobs in Shared Preferences
+* Using SQLite for isolated flags or intermediate properties
+* Complex structured data in Shared Preferences
+
+---
+
+## Team Principle
+
+**If data is state → Shared Preferences**
+**If data is records → SQLite**


### PR DESCRIPTION
Document guidelines for using SQLite DB versus Shared Preferences in mobile storage.


## Changeset Category

This PR is streamlined for review in the following category

- [ ] Modernization
- [ ] Bug Fix
- [ ] Process
- [ ] Refactor
- [ ] Performance
- [x] Documentation
