### PR TITLE
Revise Unit Testing Guidelines In Mobile Standards

### DIFF
--- a/docs/mobile_standards.md
+++ b/docs/mobile_standards.md
@@ -105,6 +105,7 @@ In short: â€œCrash early, fix quickly, and handle gracefully where it matters.â€
 - Code should be well-covered by unit tests to ensure individual components work as expected.
 - Tests should cover edge cases, error scenarios, and critical functionalities.
 - Any feature work should be accompained by [corresponding instrumentation tests]([url](https://developer.android.com/training/testing/instrumented-tests)) in cases where we are not able to verify complete functionality with the help of unit tests.
+- Any new unit testing classes should be written in Kotlin and utilize backticks to write test names as natural-language sentences (e.g. "\`ccc_generic_opportunity with session_endpoint_id routes to DispatchActivity\`").
      
 ### Documentation and Comments:
 


### PR DESCRIPTION
Based on discussions [here](https://github.com/dimagi/commcare-android/pull/3684/changes#r3169210114), I updated the guidelines for unit testing to specify Kotlin usage and naming conventions.